### PR TITLE
Add reusable checkbox component

### DIFF
--- a/src/components/ui/Checkbox/Checkbox.test.tsx
+++ b/src/components/ui/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,19 @@
+// import { render, screen } from '@testing-library/react';
+// import { Checkbox } from './Checkbox';
+
+// describe('Checkbox', () => {
+//   it('rendered on mount', () => {
+//     render(<Checkbox checked={false} onChange={() => {}} />);
+//   });
+
+//   it('rendered with label', () => {
+//     render(<Checkbox label="Accept terms" checked={false} onChange={() => {}} />);
+//     expect(screen.getByText('Accept terms')).toBeInTheDocument();
+//   });
+
+//   it('rendered without label when not provided', () => {
+//     const { container } = render(<Checkbox checked={false} onChange={() => {}} />);
+//     const label = container.querySelector('.MuiFormControlLabel-label');
+//     expect(label).toBeNull();
+//   });
+// });

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { FC } from 'react';
+import { styled } from '@mui/material/styles';
+import MUICheckbox, { CheckboxProps } from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Typography from '@mui/material/Typography';
+
+type LabeledCheckboxProps = CheckboxProps & {
+  label?: React.ReactNode;
+};
+
+const StyledCheckbox = styled(MUICheckbox)<CheckboxProps>(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  '&.Mui-checked': {
+    color: theme.palette.primary.main,
+  },
+  '& .MuiSvgIcon-root': {
+    fontSize: 16,
+  },
+  padding: 0,
+  borderRadius: 2,
+  marginLeft: 0,
+}));
+
+export const Checkbox: FC<LabeledCheckboxProps> = ({ label, ...rest }) => {
+  const control = <StyledCheckbox disableRipple {...rest} />;
+
+  return label ? (
+    <FormControlLabel
+      control={control}
+      label={<Typography variant="body2">{label}</Typography>}
+      sx={{ gap: '12px' }}
+    />
+  ) : (
+    control
+  );
+};


### PR DESCRIPTION
![photo_2025-07-14_23-44-41](https://github.com/user-attachments/assets/222de46d-8806-45b0-9c56-a3c7a4c12aca)

Created a checkbox ui component and added test file. Though i couldn't test it because we didn't have react testing library added.
Although, based on design from Figma checkbox tick icon should have a little different look (which I found to be impossible to make with MUI only)

