### PR TITLE
Add ToggleButton reusable component

### DIFF
--- a/src/components/ui/ToggleButton/ToggleButton.tsx
+++ b/src/components/ui/ToggleButton/ToggleButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import MUIToggleButton, { ToggleButtonProps } from '@mui/material/ToggleButton';
+import { styled } from '@mui/material/styles';
+import { FC } from 'react';
+
+export const StyledToggleButton = styled(MUIToggleButton)<ToggleButtonProps>(
+  () => ({
+    fontSize: '15px',
+    fontWeight: 300,
+    cursor: 'pointer',
+    color: '#5C5C5C;',
+    border: '1px solid #494949',
+    backgroundColor: 'transparent',
+    width: '85px',
+    height: '55px',
+
+    '&.Mui-selected': {
+      backgroundColor: '#F0F0F0',
+      color: '#C4C4C4',
+    },
+    '&.Mui-selected:hover': {
+      backgroundColor: '#E8E8E8',
+    },
+    '&.Mui-disabled': {
+      backgroundColor: '#F9F9F9',
+      color: '#B0B0B0',
+      borderColor: '#D0D0D0',
+      cursor: 'not-allowed',
+      border: '1px solid #D0D0D0',
+    },
+    '&.MuiToggleButtonGroup-grouped.Mui-disabled': {
+      border: '1px solid #D0D0D0',
+    },
+    '&.MuiToggleButtonGroup-grouped': {
+      border: '1px solid #494949',
+      borderRadius: '8px',
+      margin: '0 4px',
+    },
+  })
+);
+
+export const ToggleButton: FC<ToggleButtonProps> = ({ ...props }) => {
+  return <StyledToggleButton {...props} />;
+};

--- a/src/components/ui/ToggleButton/ToggleButton.tsx
+++ b/src/components/ui/ToggleButton/ToggleButton.tsx
@@ -5,5 +5,5 @@ import { ToggleButtonProps } from '@mui/material/ToggleButton';
 import { StyledToggleButton } from './toggle-button.styles';
 
 export const ToggleButton: FC<ToggleButtonProps> = ({ ...props }) => {
-  return <StyledToggleButton {...props} />;
+  return <StyledToggleButton disableRipple {...props} />;
 };

--- a/src/components/ui/ToggleButton/ToggleButton.tsx
+++ b/src/components/ui/ToggleButton/ToggleButton.tsx
@@ -1,45 +1,8 @@
 'use client';
 
-import MUIToggleButton, { ToggleButtonProps } from '@mui/material/ToggleButton';
-import { styled } from '@mui/material/styles';
 import { FC } from 'react';
-
-export const StyledToggleButton = styled(MUIToggleButton)<ToggleButtonProps>(
-  () => ({
-    fontSize: '15px',
-    fontWeight: 300,
-    cursor: 'pointer',
-    color: '#5C5C5C;',
-    border: '1px solid #494949',
-    backgroundColor: 'transparent',
-    width: '85px',
-    height: '55px',
-
-    '&.Mui-selected': {
-      backgroundColor: '#F0F0F0',
-      color: '#C4C4C4',
-    },
-    '&.Mui-selected:hover': {
-      backgroundColor: '#E8E8E8',
-    },
-    '&.Mui-disabled': {
-      backgroundColor: '#F9F9F9',
-      color: '#B0B0B0',
-      borderColor: '#D0D0D0',
-      cursor: 'not-allowed',
-      border: '1px solid #D0D0D0',
-    },
-    '&.MuiToggleButtonGroup-grouped.Mui-disabled': {
-      border: '1px solid #D0D0D0',
-    },
-    '&.MuiToggleButtonGroup-grouped': {
-      border: '1px solid #494949',
-      borderRadius: '8px',
-      margin: '0',
-      padding: '0',
-    },
-  })
-);
+import { ToggleButtonProps } from '@mui/material/ToggleButton';
+import { StyledToggleButton } from './toggle-button.styles';
 
 export const ToggleButton: FC<ToggleButtonProps> = ({ ...props }) => {
   return <StyledToggleButton {...props} />;

--- a/src/components/ui/ToggleButton/ToggleButton.tsx
+++ b/src/components/ui/ToggleButton/ToggleButton.tsx
@@ -35,7 +35,8 @@ export const StyledToggleButton = styled(MUIToggleButton)<ToggleButtonProps>(
     '&.MuiToggleButtonGroup-grouped': {
       border: '1px solid #494949',
       borderRadius: '8px',
-      margin: '0 4px',
+      margin: '0',
+      padding: '0',
     },
   })
 );

--- a/src/components/ui/ToggleButton/ToggleButton.tsx
+++ b/src/components/ui/ToggleButton/ToggleButton.tsx
@@ -4,6 +4,6 @@ import { FC } from 'react';
 import { ToggleButtonProps } from '@mui/material/ToggleButton';
 import { StyledToggleButton } from './toggle-button.styles';
 
-export const ToggleButton: FC<ToggleButtonProps> = ({ ...props }) => {
+export const ToggleButton: FC<ToggleButtonProps> = (props) => {
   return <StyledToggleButton disableRipple {...props} />;
 };

--- a/src/components/ui/ToggleButton/toggle-button.styles.ts
+++ b/src/components/ui/ToggleButton/toggle-button.styles.ts
@@ -1,0 +1,42 @@
+import MUIToggleButton, { ToggleButtonProps } from '@mui/material/ToggleButton';
+import { styled } from '@mui/material/styles';
+
+export const StyledToggleButton = styled(MUIToggleButton)<ToggleButtonProps>(
+  ({ theme }) => ({
+    ...theme.typography.caption,
+
+    color: theme.palette.text.secondary,
+    border: `1px solid ${theme.palette.secondary.dark}`,
+    backgroundColor: 'transparent',
+    minWidth: '85px',
+    height: '55px',
+
+    '&.Mui-selected': {
+      backgroundColor: theme.palette.grey[200],
+      color: theme.palette.grey[400],
+    },
+
+    '&.Mui-selected:hover': {
+      backgroundColor: theme.palette.grey[300],
+    },
+
+    '&.Mui-disabled': {
+      backgroundColor: theme.palette.grey[100],
+      color: theme.palette.grey[300],
+      borderColor: theme.palette.grey[300],
+      cursor: 'not-allowed',
+      border: `1px solid ${theme.palette.grey[300]}`,
+    },
+
+    '&.MuiToggleButtonGroup-grouped.Mui-disabled': {
+      border: `1px solid ${theme.palette.grey[300]}`,
+    },
+
+    '&.MuiToggleButtonGroup-grouped': {
+      border: `1px solid ${theme.palette.secondary.dark}`,
+      borderRadius: theme.shape.borderRadius,
+      margin: '0',
+      padding: '0',
+    },
+  })
+);

--- a/src/components/ui/ToggleButton/toggle-button.styles.ts
+++ b/src/components/ui/ToggleButton/toggle-button.styles.ts
@@ -16,10 +16,6 @@ export const StyledToggleButton = styled(MUIToggleButton)<ToggleButtonProps>(
       color: theme.palette.grey[400],
     },
 
-    '&.Mui-selected:hover': {
-      backgroundColor: theme.palette.grey[300],
-    },
-
     '&.Mui-disabled': {
       backgroundColor: theme.palette.grey[100],
       color: theme.palette.grey[300],

--- a/src/components/ui/ToggleButton/toggle-button.test.tsx
+++ b/src/components/ui/ToggleButton/toggle-button.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToggleButton } from './ToggleButton';
+import '@testing-library/jest-dom';
+
+describe('ToggleButton', () => {
+  test('renders correctly', () => {
+    render(<ToggleButton value="test">Click me</ToggleButton>);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Click me');
+  });
+
+  test('calls onClick when clicked', () => {
+    const handleClick = jest.fn();
+    render(
+      <ToggleButton value="test" onClick={handleClick}>
+        Click me
+      </ToggleButton>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  test('does not call onClick when disabled', () => {
+    const handleClick = jest.fn();
+    render(
+      <ToggleButton value="test" onClick={handleClick} disabled>
+        Disabled
+      </ToggleButton>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  test('applies selected styles when selected', () => {
+    render(
+      <ToggleButton value="test" selected>
+        Selected
+      </ToggleButton>
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('Mui-selected');
+    expect(button).toHaveStyle('background-color: #F0F0F0');
+  });
+
+  test('applies disabled styles when disabled', () => {
+    render(
+      <ToggleButton value="test" disabled>
+        Disabled
+      </ToggleButton>
+    );
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveStyle('background-color: #F9F9F9');
+  });
+});

--- a/src/components/ui/ToggleButton/toggle-button.test.tsx
+++ b/src/components/ui/ToggleButton/toggle-button.test.tsx
@@ -40,7 +40,6 @@ describe('ToggleButton', () => {
     );
     const button = screen.getByRole('button');
     expect(button).toHaveClass('Mui-selected');
-    expect(button).toHaveStyle('background-color: #F0F0F0');
   });
 
   test('applies disabled styles when disabled', () => {
@@ -51,6 +50,5 @@ describe('ToggleButton', () => {
     );
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
-    expect(button).toHaveStyle('background-color: #F9F9F9');
   });
 });

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,3 @@
 export { Button } from './Button/Button';
 export { IconButton } from './IconButton/IconButton';
+export { ToggleButton } from './ToggleButton/ToggleButton';


### PR DESCRIPTION

Selected - non selected - disabled

I had to add styles to the disabled one because we didn't have one in the design. Also the default MUI for disabled was looking bad.

<img width="594" height="115" alt="image" src="https://github.com/user-attachments/assets/51377e53-750e-4ecc-9c8a-5abd8e9c716f" />

Picture of the design (selected - non selected): 

<img width="371" height="128" alt="image" src="https://github.com/user-attachments/assets/7d967121-8c5c-4a28-9d0d-f5148290e8d2" />

I was thinking maybe the 'selected' one in the design is the appareance for the 'disabled', it's ambiguous. I took it as 'selected'.

