### PR TITLE
Add PopUpMenu reusable component

### DIFF
--- a/src/components/ui/PopUpMenu/PopUpMenu.tsx
+++ b/src/components/ui/PopUpMenu/PopUpMenu.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { FC } from 'react';
+import { MenuProps } from '@mui/material/Menu';
+import { StyledMenu } from './pop-up-menu.styles';
+
+export const PopUpMenu: FC<MenuProps> = (props) => {
+  return (
+    <StyledMenu
+      elevation={0}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'right',
+      }}
+      {...props}
+    />
+  );
+};

--- a/src/components/ui/PopUpMenu/pop-up-menu.styles.ts
+++ b/src/components/ui/PopUpMenu/pop-up-menu.styles.ts
@@ -1,0 +1,22 @@
+import { styled } from '@mui/material/styles';
+import Menu, { MenuProps } from '@mui/material/Menu';
+
+export const StyledMenu = styled(Menu)<MenuProps>(({ theme }) => ({
+  '& .MuiPaper-root': {
+    borderRadius: theme.shape.borderRadius,
+    minWidth: 75,
+    boxShadow: `0px 4px 10px rgba(0, 0, 0, 0.15)`,
+    '& .MuiMenu-list': {
+      padding: 0,
+      marginBottom: 8,
+    },
+    '& .MuiMenuItem-root': {
+      ...theme.typography.caption,
+      lineHeight: '14px',
+      color: theme.palette.text.primary,
+      padding: 8,
+      margin: 0,
+      minHeight: 22,
+    },
+  },
+}));

--- a/src/components/ui/PopUpMenu/pop-up-menu.test.tsx
+++ b/src/components/ui/PopUpMenu/pop-up-menu.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PopUpMenu } from './PopUpMenu';
+import { MenuItem } from '@mui/material';
+import '@testing-library/jest-dom';
+
+describe('PopUpMenu', () => {
+  test('renders when open and displays children', () => {
+    const anchor = document.createElement('div');
+    document.body.appendChild(anchor);
+
+    render(
+      <PopUpMenu anchorEl={anchor} open onClose={jest.fn()}>
+        <MenuItem>Item 1</MenuItem>
+        <MenuItem>Item 2</MenuItem>
+      </PopUpMenu>
+    );
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+  });
+
+  test('does not render when `open` is false', () => {
+    const anchor = document.createElement('div');
+    document.body.appendChild(anchor);
+
+    render(
+      <PopUpMenu anchorEl={anchor} open={false} onClose={jest.fn()}>
+        <MenuItem>Hidden Item</MenuItem>
+      </PopUpMenu>
+    );
+
+    expect(screen.queryByText('Hidden Item')).not.toBeInTheDocument();
+  });
+
+  test('calls onClose when a menu item is clicked', () => {
+    const anchor = document.createElement('div');
+    document.body.appendChild(anchor);
+    const handleClose = jest.fn();
+
+    render(
+      <PopUpMenu anchorEl={anchor} open onClose={handleClose}>
+        <MenuItem onClick={handleClose}>Close Me</MenuItem>
+      </PopUpMenu>
+    );
+
+    fireEvent.click(screen.getByText('Close Me'));
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 export { Button } from './Button/Button';
 export { IconButton } from './IconButton/IconButton';
 export { ToggleButton } from './ToggleButton/ToggleButton';
+export { PopUpMenu } from './PopUpMenu/PopUpMenu';


### PR DESCRIPTION

Mine:
<img width="328" height="458" alt="image" src="https://github.com/user-attachments/assets/4adb6444-15b0-43a4-8013-b61d5ef0c88b" />

Design:
<img width="458" height="486" alt="image" src="https://github.com/user-attachments/assets/e4a684cc-ee41-4c6e-8d1f-c36a4f1e2e06" />


To test it in home fast you can do:
`'use client';
import * as React from 'react';
import Button from '@mui/material/Button';
import MenuItem from '@mui/material/MenuItem';
import { PopUpMenu } from '@/components/ui'; 

export default function Home() {
  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
  const open = Boolean(anchorEl);
  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
    setAnchorEl(event.currentTarget);
  };

   const handleClose = () => {
    setAnchorEl(null);
  };

  const handleEdit = () => {
    handleClose();
  };

  const handleView= () => {
    handleClose();
  };

  const handleDuplicate= () => {
    handleClose();
  };

  const handleDelete= () => {
    handleClose();
  };

  return (
    <div>
      <Button
        id="demo-customized-button"
        aria-controls={open ? 'demo-customized-menu' : undefined}
        aria-haspopup="true"
        aria-expanded={open ? 'true' : undefined}
        disableElevation
        onClick={handleClick}
        style={{marginLeft: '150px'}}
      >
        ...
      </Button>
      <PopUpMenu
        id="demo-customized-menu"
        anchorEl={anchorEl}
        open={open}
        onClose={handleClose}
      >
        <MenuItem onClick={handleView} disableRipple>
          View
        </MenuItem>
        <MenuItem onClick={handleEdit} disableRipple>
          Edit
        </MenuItem>
        <MenuItem onClick={handleDuplicate} disableRipple>
          Duplicate
        </MenuItem>
        <MenuItem onClick={handleDelete} disableRipple>
          Delete
        </MenuItem>
      </PopUpMenu>
    </div>
  );
}`